### PR TITLE
Replace tables with list-based responses, improve user interface and error handling, add summary of work to logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Run app.py to launch Timelord
 - `/help` Get this list of commands
 - `/timelog` Open a time logging form
 - `/deletelast` Delete your last entry
-- `/myentries n` Get your last n entries (defaults to 5)"""
+- `/myentries n` Get your last n entries (defaults to 5)
 
 #### Admin Commands:
 - `/timelog` Open a time logging form
 - `/deletelast` Delete your last entry
-- `/myentries n` Get your last n entries (defaults to 30)"""
+- `/myentries n` Get your last n entries (defaults to 30)
 - `/gethours` Select users and see their total hours logged
 - `/getentries` Select users and see their most recent entries
 - `/lastentries n` See the last n entries from all users in one list (defaults to 30)
 - `/leaderboard` Select a date range and rank all users by hours logged in that range
-- `/dateoverview` See all entries for a given date"""
+- `/dateoverview` See all entries for a given date
 
 ## Autostart
 Change the paths in `timelord.service` to match where you have put it, then copy `timelord.serivce` into

--- a/README.md
+++ b/README.md
@@ -24,18 +24,22 @@ Run app.py to launch Timelord
 
 #### User Commands:
 - `/help` Get this list of commands
-- `/timelog` Opens a time logging form
+- `/timelog` Open a time logging form
 - `/deletelast` Delete your last entry
-- `/myentries n` Get a table with your last n entries (defaults to 5)
+- `/myentries n` Get your last n entries (defaults to 5)"""
 
 #### Admin Commands:
-- `/gethours` Select users and get their total hours logged
-- `/allusersums` Get the total hours logged by all users
-- `/getusertables` Select users to see their last few entries
-- `/allusertable` Responds with the last 30 entries from all users
-- `/leaderboard n` Responds with the top n contributors and their total time logged (defaults to 10)
+- `/timelog` Open a time logging form
+- `/deletelast` Delete your last entry
+- `/myentries n` Get your last n entries (defaults to 30)"""
+- `/gethours` Select users and see their total hours logged
+- `/getentries` Select users and see their most recent entries
+- `/lastentries n` See the last n entries from all users in one list (defaults to 30)
+- `/leaderboard` Select a date range and rank all users by hours logged in that range
+- `/dateoverview` See all entries for a given date"""
 
 ## Autostart
 Change the paths in `timelord.service` to match where you have put it, then copy `timelord.serivce` into
 `/etc/systemd/system` and finally run `sudo systemctl enable timelord` and `sudo systemctl start timelord`.
 Use `sudo systemctl status timelord` to view the program's status.
+

--- a/app.py
+++ b/app.py
@@ -264,10 +264,10 @@ def help(ack, respond, body):
     if(is_admin(body['user_id'])):
         output += """
     \n*Admin Commands:*
-    */gethours* Select users and to see their total hours logged
-    */getentries* Select users to see their most recent entries
-    */lastentries n* See the last 30 entries from all users
-    */leaderboard* See everyone who has made contributions in the date range ranked by hours logged
+    */gethours* Select users and see their total hours logged
+    */getentries* Select users and see their most recent entries
+    */lastentries n* See the last n entries from all users in one list (defaults to 30)
+    */leaderboard* Select a date range and rank all users by hours logged in that range
     */dateoverview* See all entries for a given date"""
     respond(output)
 

--- a/app.py
+++ b/app.py
@@ -235,7 +235,7 @@ def leaderboard_response(ack, body, respond, logger, command):
             name = contributor['name']
             # Add custom display name if applicable
             if contributor['display_name'] != "": name += f" ({contributor['display_name']})"
-            output += f"{name}: {(contributor['minutes']//60)} hours and {contributor['minutes']%60} minutes\n"
+            output += f"{name}: {(contributor['totalMinutes']//60)} hours and {contributor['totalMinutes']%60} minutes\n"
         respond(output)
     else:
         respond(f"No hours logged between {au_start_date} and {au_end_date}!")

--- a/app.py
+++ b/app.py
@@ -180,15 +180,16 @@ def get_date_overview(ack, body, respond, logger):
 def leaderboard(ack, body, respond, logger, command):
     ack()
     if(is_admin(body['user_id'])):
-        respond(blocks=blocks.dateoverview_form())
+        respond(blocks=blocks.leaderboard_form())
     else:
         respond("You must be an admin to use this command!")
 
 @app.action("leaderboard_response")
-def leaderboard_response(ack, body, respond, logger, command)
+def leaderboard_response(ack, body, respond, logger, command):
+    ack()
     try:
         user_id = body['user_id']
-        num_users = int(command['text']) if command['text'] != "" else 10 # Defaults to 5 entries
+        num_users = int(command['text']) if command['text'] != "" else 10 # Defaults to 10 entries
     except:
         logger.exception("Invalid user input, failed to fetch leaderboard")
         respond("*Invalid input!* Please try again! You can get a leaderboard with n users with `/leaderboard n`. If you leave n blank a default value of 10 will be used.")

--- a/app.py
+++ b/app.py
@@ -186,14 +186,17 @@ def leaderboard_response(ack, body, respond, logger, command):
     date_constraint_text = body['state']['values']['date_constraint_block']['date_constraint_input']['selected_option']['value']
     date_constraint = parse_date_constraint(date_constraint_text)
     sqlc = database.SQLConnection()
-    contributions = sqlc.leaderboard(date_constraint) if date_constraint else sqlc.leaderboard(date_constraint) 
-    output = f"*All contributors for {date_constraint_text} ranked by hours logged*\n"
-    for i in contributions:
-        # Add custom display name if applicable
-        name = i[0]
-        if i[1] != "": name += " ("+i[1]+")"
-        output += f"{name}: {int(i[2]/60)} hours and {int(i[2]%60)} minutes\n"
-    respond(output)
+    contributions = sqlc.leaderboard(date_constraint)
+    if contributions():
+        output = f"*All contributors for {date_constraint_text} ranked by hours logged*\n"
+        for i in contributions:
+            # Add custom display name if applicable
+            name = i[0]
+            if i[1] != "": name += " ("+i[1]+")"
+            output += f"{name}: {int(i[2]/60)} hours and {int(i[2]%60)} minutes\n"
+        respond(output)
+    else:
+        respond(f"No hours logged {date_constraint_text}!")
 
 ################################### Commands without forms ###################################
 

--- a/app.py
+++ b/app.py
@@ -106,6 +106,9 @@ def get_logged_hours(ack, body, respond, logger):
         if not (users and start_date and end_date):
             raise ValueError("Missing required field")
 
+        start_date = datetime.strptime(start_date, "%Y-%m-%d")
+        end_date = datetime.strptime(end_date, "%Y-%m-%d")
+
     except ValueError as e:
         respond(f"*Invalid input, please try again!* {str(e)}.")
         logger.warning(e)
@@ -219,12 +222,6 @@ def leaderboard_response(ack, body, respond, logger, command):
     try:
         start_date = body['state']['values']['date_select_block_start']['date_select_input']['selected_date']
         end_date = body['state']['values']['date_select_block_end']['date_select_input']['selected_date']
-
-        print(start_date)
-        print(end_date)
-
-        print(type(start_date))
-        print(type(end_date))
 
         if not (start_date and end_date):
             raise ValueError("Both a start and end date must be specified")

--- a/app.py
+++ b/app.py
@@ -36,13 +36,14 @@ def parse_date_constraint(constraint):
     # Requires python 3.10 or higher
     match constraint:
         case "today": 
-            return today.strftime('%Y-%m-%d')
+            # This isn't great but it probably won't be used often
+            return date_range(today.strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
         case "this week":
             # Move back n days where n is the weekday number (so we reach the start of the week (Monday is 0, Sunday is 6))
-            return date_range(today - timedelta(days=today.weekday()), today).strftime('%Y-%m-%d')
+            return date_range((today - timedelta(days=today.weekday())).strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
         case "this month":
             # Replace the day part of the date with 1 (2022-11-23 becomes 2022-11-01)
-            return date_range(today.replace(day=1), today).strftime('%Y-%m-%d')
+            return date_range((today.replace(day=1)).strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
         case "all time":
             # Empty string - SQLite uses strings to store dates and this is the smallest possible string lexicographically
             return None
@@ -88,7 +89,6 @@ def submit_timelog_form(ack, respond, body, logger):
 
         logger.info(f"New log entry of {time_input[0]} hours and {time_input[1]} minutes for {selected_date} by {user_id}")
 
-        # Open an SQL connection and add entry to database containing user input
         sqlc = database.SQLConnection()
         sqlc.insert_timelog_entry(user_id, selected_date, minutes)
 

--- a/app.py
+++ b/app.py
@@ -234,7 +234,7 @@ def leaderboard_response(ack, body, respond, logger, command):
         for contributor in contributors:
             name = contributor['name']
             # Add custom display name if applicable
-            if contributor[['display_name']] != "": name += f" ({contributor[['display_name']]})"
+            if contributor['display_name'] != "": name += f" ({contributor['display_name']})"
             output += f"{name}: {(contributor['minutes']//60)} hours and {contributor['minutes']%60} minutes\n"
         respond(output)
     else:

--- a/app.py
+++ b/app.py
@@ -2,15 +2,9 @@ import os, re, logging, blocks, database
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_sdk import WebClient
-from slack_sdk.errors import SlackApiError
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 from pathlib import Path
-from collections import namedtuple
-
-import sys
-if not sys.version_info >= (3, 10):
-    raise Exception("Requires Python 3.10 or higher!")
 
 dotenv_path = Path(".env")
 if dotenv_path.exists():

--- a/app.py
+++ b/app.py
@@ -292,7 +292,7 @@ def select_date(ack, body, logger):
     ack()
     logger.debug(body)
 
-@app.action("time_constraint_input")
+@app.action("date_constraint_input")
 def handle_some_action(ack, body, logger):
     ack()
     logger.debug(body)

--- a/app.py
+++ b/app.py
@@ -59,11 +59,11 @@ def submit_timelog_form(ack, respond, body, logger):
         if not (select_date and time_input and summary):
             raise ValueError("Missing required field")
         
-        time_list = re.findall(r'\d+', time_input) # List with two ints
+        time_inputs = re.findall(r'\d+', time_input) # List with two ints
 
         if (len(summary) > 70):
             raise ValueError("Summary must be under 70 characters")
-        if not (all(i.isdigit() for i in time_list) and len(time_list) == 2):
+        if not (all(time_input.isdigit() for time_input in time_inputs) and len(time_inputs) == 2):
             raise ValueError("Time logged field must contain two numbers seperated by some characters (e.g. 3h 25m)")
 
     except ValueError as e:
@@ -71,11 +71,11 @@ def submit_timelog_form(ack, respond, body, logger):
         logger.warning(e)
         return
 
-    minutes = int(time_list[0])*60 + int(time_list[1])    # user input (hours and minutes) stored as minutes only
-    logger.info(f"New log entry of {time_list[0]} hours and {time_list[1]} minutes for {selected_date} by {user_id}")
+    minutes = int(time_inputs[0])*60 + int(time_inputs[1])    # user input (hours and minutes) stored as minutes only
+    logger.info(f"New log entry of {time_inputs[0]} hours and {time_inputs[1]} minutes for {selected_date} by {user_id}")
     sqlc = database.SQLConnection()
     sqlc.insert_timelog_entry(user_id, selected_date, minutes, summary)
-    respond(f"Time logged: {time_list[0]} hours and {time_list[1]} minutes for date {selected_date}.")
+    respond(f"Time logged: {time_inputs[0]} hours and {time_inputs[1]} minutes for date {selected_date}.")
 
 
 
@@ -100,9 +100,6 @@ def get_logged_hours(ack, body, respond, logger):
         if not (users and start_date and end_date):
             raise ValueError("Missing required field")
 
-        start_date = datetime.strptime(start_date, "%Y-%m-%d")
-        end_date = datetime.strptime(end_date, "%Y-%m-%d")
-
     except ValueError as e:
         respond(f"*Invalid input, please try again!* {str(e)}.")
         logger.warning(e)
@@ -111,11 +108,11 @@ def get_logged_hours(ack, body, respond, logger):
     sqlc = database.SQLConnection()
     output = ""
     # Add the time logged by each user to the output
-    for i in users:
-        name = user_name(i)
-        user_time = sqlc.time_sum(i, start_date, end_date)
+    for user in users:
+        name = user_name(user)
+        user_time = sqlc.time_sum(user, start_date, end_date)
         if (user_time > 0):
-            output += f"*{name}*: {int(user_time/60)} hours and {int(user_time%60)} minutes\n"
+            output += f"*{name}*: {user_time//60} hours and {user_time%60} minutes\n"
         else:
             output += f"*{name}* has no logged hours\n"
     respond(output)
@@ -156,9 +153,9 @@ def get_logged_hours(ack, body, respond, logger):
         output += f"\n\n\n*{user_name(user)}*"
         entries = sqlc.given_user_entries_list(user, num_entries)
         if entries:
-            for i in entries:
-                output += f"\n\n  •  {i[0]} / {int(i[1]/60):2} hours and {i[1]%60:2} minutes / Submitted {i[2]} / "
-                output += f"_{i[3]}_" if i[3] else "No summary given"
+            for entry in entries:
+                output += f"\n\n  •  {entry[0]} / {(entry[1]//60):2} hours and {(entry[1]%60):2} minutes / Submitted {entry[2]} / "
+                output += f"_{entry[3]}_" if entry[3] else "No summary given"
         else:
             output += "\n\n  •  No entries"
     respond(output)
@@ -190,11 +187,11 @@ def get_date_overview(ack, body, respond, logger):
     entries = sqlc.entries_for_date_list(selected_date)
     output = f"*Overview for {selected_date}*"
     if entries:
-        for i in entries:
-            name = i[0]
-            if i[1] != "": name += " ("+i[1]+")"
-            output += f"\n\n  •  {name} / {int(i[2]/60):2} hours and {i[2]%60:2} minutes / "
-            output += f"_{i[3]}_" if i[3] else "No summary given"
+        for entry in entries:
+            name = entry[0]
+            if entry[1] != "": name += " ("+entry[1]+")"
+            output += f"\n\n  •  {name} / {(entry[2]//60):2} hours and {(entry[2]%60):2} minutes / "
+            output += f"_{entry[3]}_" if entry[3] else "No summary given"
     else:
         output += "\n\n  •  No entries"
     respond(output)
@@ -226,20 +223,20 @@ def leaderboard_response(ack, body, respond, logger, command):
         return
 
     sqlc = database.SQLConnection()
-    contributions = sqlc.leaderboard(start_date, end_date)
+    contributors = sqlc.leaderboard(start_date, end_date)
     
     # Doing this means we are converting from date object to string, to date object, and then back to string
     # I still think this is the best approach because it is clearer and easier to read than a string manipulation
     au_start_date = datetime.strptime(start_date, "%Y-%m-%d").strftime("%d/%m/%y")
     au_end_date = datetime.strptime(end_date, "%Y-%m-%d").strftime("%d/%m/%y")
 
-    if contributions:
+    if contributors:
         output = f"*All contributors between {au_start_date} and {au_end_date} ranked by hours logged*\n"
-        for i in contributions:
+        for contributor in contributors:
+            name = contributor[0]
             # Add custom display name if applicable
-            name = i[0]
-            if i[1] != "": name += " ("+i[1]+")"
-            output += f"{name}: {int(i[2]/60)} hours and {int(i[2]%60)} minutes\n"
+            if contributor[1] != "": name += f" ({contributor[1]})"
+            output += f"{name}: {(contributor[2]//60)} hours and {contributor[2]%60} minutes\n"
         respond(output)
     else:
         respond(f"No hours logged between {au_start_date} and {au_end_date}!")
@@ -286,16 +283,17 @@ def user_entries(ack, respond, body, command, logger):
     sqlc = database.SQLConnection()
     entries = sqlc.given_user_entries_list(user_id, num_entries)
     today = datetime.today()
-    yearly_minutes = sqlc.time_sum(user_id, today - timedelta(days=365), today)
-    weekly_minutes = sqlc.time_sum(user_id, today - timedelta(days=today.weekday()), today)
+    yearly_minutes = sqlc.time_sum(user_id, (today - timedelta(days=365)).strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
+    weekly_minutes = sqlc.time_sum(user_id, (today - timedelta(days=today.weekday())).strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
 
-    output = f"\n*Hours logged in the last 365 days*: {int(yearly_minutes/60)} hours and {yearly_minutes%60} minutes"
-    output += f"\n*Hours logged this week:* {int(weekly_minutes/60)} hours and {weekly_minutes%60} minutes"
+    output = f"\n*Hours logged in the last 365 days*: {yearly_minutes//60} hours and {yearly_minutes%60} minutes"
+    output += f"\n*Hours logged this week:* {weekly_minutes//60} hours and {weekly_minutes%60} minutes"
     
     if entries:
-        for i in entries:
-            output += f"\n\n  •  {i[0]} / {int(i[1]/60):2} hours and {i[1]%60:2} minutes / Submitted {i[2]} / "
-            output += f"_{i[3]}_" if i[3] else "No summary given"
+        for entry in entries:
+            # restricting hours and minutes to 2 characters makes the list look nicer
+            output += f"\n\n  •  {entry[0]} / {(entry[1]//60):2} hours and {(entry[1]%60):2} minutes / Submitted {entry[2]} / "
+            output += f"_{entry[3]}_" if entry[3] else "No summary given"
     else:
         output += "\n\n  •  No entries"
     respond(output)
@@ -331,11 +329,11 @@ def log_database(ack, body, respond, command, logger):
 
         output = f"*Last {num_entries} entries from all users*"
         if entries:
-            for i in entries:
-                name = i[0]
-                if i[1] != "": name += " ("+i[1]+")"
-                output += f"\n\n  •  {name} / {i[2]} / {int(i[3]/60):2} hours and {i[3]%60:2} minutes / Submitted {i[4]} / "
-                output += f"_{i[5]}_" if i[5] else "No summary given"
+            for entry in entries:
+                name = entry[0]
+                if entry[1] != "": name += f" {(entry[1])}"
+                output += f"\n\n  •  {name} / {entry[2]} / {(entry[3]//60):2} hours and {(entry[3]%60):2} minutes / Submitted {entry[4]} / "
+                output += f"_{entry[5]}_" if entry[5] else "No summary given"
         else:
             output += "\n\n  •  No entries"
 

--- a/app.py
+++ b/app.py
@@ -198,7 +198,7 @@ def leaderboard_response(ack, body, respond, logger, command):
     print(date_constraint)
 
     sqlc = database.SQLConnection()
-    contributions = sqlc.leaderboard(num_users, date_constraint) if date_constraint else sqlc.leaderboard(num_users) 
+    contributions = sqlc.leaderboard(date_constraint) if date_constraint else sqlc.leaderboard(date_constraint) 
     output = f"*Top {num_users} contributors*\n"
     for i in contributions:
         # Add custom display name if applicable
@@ -221,7 +221,6 @@ def help(ack, respond, body, command):
         output += """
     \n*Admin Commands:*
     */gethours* Select users and get their total hours logged
-    */allusersums* Get the total hours logged by all users
     */getusertables* Select users to see their last few entries
     */allusertable* Responds with the last 30 entries from all users
     */leaderboard n* Responds with the top n contributors and their total time logged (defaults to 10)"""
@@ -251,25 +250,6 @@ def delete_last(ack, respond, body, command):
     sqlc = database.SQLConnection()
     sqlc.remove_last_entry(body['user_id'])
     respond("Last entry removed!")
-
-# Respond with the total time logged by all users
-@app.command("/allusersums")
-def get_logged_hours(ack, body, respond, logger):
-    ack()
-    if(is_admin(body['user_id'])):
-        sqlc = database.SQLConnection()
-        user_sum = sqlc.all_time_sums()
-        output = ""
-        # Add the time logged by each user to the output
-        for user in user_sum:
-            # Add a custom display name if the user has one set
-            display_name = " ("+user[1]+")" if user[1] != "" else ""
-            output += f"*{user[0]}*{display_name}: {int(user[2]/60)} hours and {int(user[2]%60)} minutes\n"
-        # Send output to Slack chat and console
-        logger.info("\n" + output)
-        respond(output)
-    else:
-        respond("You must be an admin to use this command!")
 
 # Respond with last 30 hours entered by all users
 @app.command("/allusertable")

--- a/app.py
+++ b/app.py
@@ -232,9 +232,9 @@ def leaderboard_response(ack, body, respond, logger, command):
     if contributors:
         output = f"*All contributors between {au_start_date} and {au_end_date} ranked by hours logged*\n"
         for contributor in contributors:
-            name = contributor[0]
+            name = contributor['name']
             # Add custom display name if applicable
-            if contributor[1] != "": name += f" ({contributor[1]})"
+            if contributor[['display_name']] != "": name += f" ({contributor[['display_name']]})"
             output += f"{name}: {(contributor['minutes']//60)} hours and {contributor['minutes']%60} minutes\n"
         respond(output)
     else:

--- a/app.py
+++ b/app.py
@@ -235,7 +235,7 @@ def leaderboard_response(ack, body, respond, logger, command):
             name = contributor['name']
             # Add custom display name if applicable
             if contributor['display_name'] != "": name += f" ({contributor['display_name']})"
-            output += f"{name}: {(contributor['totalMinutes']//60)} hours and {contributor['totalMinutes']%60} minutes\n"
+            output += f"{name}: {contributor['totalMinutes']//60} hours and {contributor['totalMinutes']%60} minutes\n"
         respond(output)
     else:
         respond(f"No hours logged between {au_start_date} and {au_end_date}!")
@@ -328,7 +328,7 @@ def log_database(ack, body, respond, command, logger):
         if entries:
             for entry in entries:
                 name = entry['name']
-                if entry['display_name'] != "": name += f" {(entry['display_name'])}"
+                if entry['display_name'] != "": name += f" ({entry['display_name']})"
                 output += f"\n\n  •  {name} / {entry['selected_date']} / {(entry['minutes']//60):2} hours and {(entry['minutes']%60):2} minutes / Submitted {entry['entry_date']} / "
                 output += f"_{entry['summary']}_" if entry['summary'] else "No summary given"
         else:

--- a/app.py
+++ b/app.py
@@ -134,13 +134,16 @@ def get_logged_hours(ack, body, respond, logger):
     ack()
     try:
         users = body['state']['values']['user_select_block']['user_select_input']['selected_users']
-        num_entries_input = body['state']['values']['num_entries_block']['num_entries_input']['value']
+        num_entries_input_text = body['state']['values']['num_entries_block']['num_entries_input']['value']
 
-        if not (users and num_entries_input):
+        if not (users and num_entries_input_text):
             raise ValueError("Missing required field")
 
-        try: num_entries = int(re.findall(r'\d+', num_entries_input)[0])
-        except: raise ValueError("Number of entries must be an integer")
+        num_entries_input = re.findall(r'\d+', num_entries_input_text)
+        if len(num_entries_input) == 1 and num_entries_input[0].isdigit():
+            num_entries = int(num_entries_input[0])
+        else: 
+            raise ValueError("Number of entries must be a single positive integer")
     
     except ValueError as e:
         respond(f"*Invalid input, please try again!* {str(e)}.")

--- a/app.py
+++ b/app.py
@@ -264,6 +264,12 @@ def select_date(ack, body, logger):
     ack()
     logger.debug(body)
 
+@app.action("time_constraint_input")
+def handle_some_action(ack, body, logger):
+    ack()
+    logger.info(body)
+
+
 if __name__ == "__main__":
     # Create tables
     database.create_log_table()

--- a/app.py
+++ b/app.py
@@ -37,13 +37,13 @@ def parse_date_constraint(constraint):
     match constraint:
         case "today": 
             # This isn't great but it probably won't be used often
-            return date_range(today.strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
+            return date_range(today, today)
         case "this week":
             # Move back n days where n is the weekday number (so we reach the start of the week (Monday is 0, Sunday is 6))
-            return date_range((today - timedelta(days=today.weekday())).strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
+            return date_range((today - timedelta(days=today.weekday())), today)
         case "this month":
             # Replace the day part of the date with 1 (2022-11-23 becomes 2022-11-01)
-            return date_range((today.replace(day=1)).strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
+            return date_range((today.replace(day=1)), today)
         case "all time":
             # Empty string - SQLite uses strings to store dates and this is the smallest possible string lexicographically
             return None
@@ -176,6 +176,7 @@ def get_date_overview(ack, body, respond, logger):
     ack()
     selected_date = datetime.strptime(body['state']['values']['date_select_block']['date_select_input']['selected_date'], "%Y-%m-%d").date()
     sqlc = database.SQLConnection()
+    print(selected_date)
     table = sqlc.entries_for_date_table(selected_date)
     respond("\n" + slack_table(f"All entries for {selected_date}", table))
 

--- a/blocks.py
+++ b/blocks.py
@@ -71,60 +71,6 @@ user_select_block = {
     }
 }
 
-date_constraint_block = {
-    "block_id": "date_constraint_block",
-    "type": "input",
-    "element": {
-        "type": "static_select",
-        "initial_option": {
-            "text": {
-                "type": "plain_text",
-                "text": "This year",
-            },
-            "value": "this year"
-        },
-        "placeholder": {
-            "type": "plain_text",
-            "text": "Select an item",
-        },
-        "options": [
-            {
-                "text": {
-                    "type": "plain_text",
-                    "text": "This year",
-                },
-                "value": "this year"
-            },
-            {
-                "text": {
-                    "type": "plain_text",
-                    "text": "Today",
-                },
-                "value": "today"
-            },
-            {
-                "text": {
-                    "type": "plain_text",
-                    "text": "This week",
-                },
-                "value": "this week"
-            },
-            {
-                "text": {
-                    "type": "plain_text",
-                    "text": "This month",
-                },
-                "value": "this month"
-            }
-        ],
-        "action_id": "date_constraint_input"
-    },
-    "label": {
-        "type": "plain_text",
-        "text": "Selection range",
-    }
-}
-
 def text_field_block(label, max_length):
     return {
         "type": "input",
@@ -182,7 +128,6 @@ def timelog_form():
     return [
         date_select_block("Date to log", date.today()),
         hours_input_block,
-        # 72 characters is the max length of a git commit message
         text_field_block("Summary of work done", 70),
         submit_button_block("timelog_response")
     ]

--- a/blocks.py
+++ b/blocks.py
@@ -194,7 +194,6 @@ def dateoverview_form():
 
 def leaderboard_form():
     return [
-        num_users_block,
         date_constraint_block,
         submit_button_block("leaderboard_response")
     ]

--- a/blocks.py
+++ b/blocks.py
@@ -124,13 +124,14 @@ def getusertables_form():
             # Number of entries
             "type": "input",
             "block_id": "num_entries_block",
-            "element": {
+            "element": { 
                 "type": "plain_text_input",
-                "action_id": "num_entries_input"
+                "action_id": "num_entries_input",
+                "initial_value": "20"
             },
             "label": {
                 "type": "plain_text",
-                "text": "Number of entries to return for each user",
+                "text": "Maximum number of entries to return for each user",
             }
         },
         # Add a date constraint selector
@@ -149,7 +150,6 @@ def getusertables_form():
             ]
         }
     ]
-    print(output)
     return output
 
 # If a seperate submit button is used a listener function will catch the default date_constraint_input event so it
@@ -159,9 +159,18 @@ def date_constraint():
     # response_endpoint with the given date constraint
     today = datetime.today()
     output = {
+        "block_id": "date_constraint_block",
         "type": "input",
         "element": {
             "type": "static_select",
+            # Default to all time
+            "initial_option": {
+                "text": {
+                    "type": "plain_text",
+                    "text": "All time",
+                },
+                "value": "all time"
+            },
             "placeholder": {
                 "type": "plain_text",
                 "text": "Select an item",
@@ -172,7 +181,7 @@ def date_constraint():
                         "type": "plain_text",
                         "text": "All time",
                     },
-                    "value": "all_time"
+                    "value": "all time"
                 },
                 {
                     "text": {
@@ -190,14 +199,14 @@ def date_constraint():
                     # Move back n days where n is the weekday number (so we reach the start of the week)
                     # Monday is 0 and Sunday is 6 here
                     # "value": today - timedelta(days = today.weekday())
-                    "value": "this_week"
+                    "value": "this week"
                 },
                 {
                     "text": {
                         "type": "plain_text",
                         "text": "This month",
                     },
-                    "value": "this_month"
+                    "value": "this month"
                     # Replace the day part of the date with 1 (2022-11-23 becomes 2022-11-01)
                     # "value": today.replace(day=1)
                 }

--- a/blocks.py
+++ b/blocks.py
@@ -21,6 +21,22 @@ num_entries_block = {
     }
 }
 
+num_users_block = {
+    # Number of entries
+    "type": "input",
+    "block_id": "num_users_block",
+    "element": { 
+        "type": "plain_text_input",
+        "action_id": "num_users_input",
+        "initial_value": "10"
+    },
+    "label": {
+        "type": "plain_text",
+        "text": "Number of users to return",
+    }
+}
+
+
 hours_input_block = {
     # Hours input
     "type": "input",
@@ -98,7 +114,7 @@ date_constraint_block = {
                 "value": "this month"
             }
         ],
-        "action_id": "time_constraint_input"
+        "action_id": "date_constraint_input"
     },
     "label": {
         "type": "plain_text",
@@ -166,7 +182,7 @@ def getusertables_form():
     return [
         user_select_block,
         num_entries_block,
-        date_constraint_block(),
+        date_constraint_block,
         submit_button_block("getusertables_response")
     ]
 
@@ -178,6 +194,7 @@ def dateoverview_form():
 
 def leaderboard_form():
     return [
-        date_select_block(),
+        num_users_block,
+        date_constraint_block,
         submit_button_block("leaderboard_response")
     ]

--- a/blocks.py
+++ b/blocks.py
@@ -2,365 +2,182 @@
 
 from datetime import datetime, timedelta
 
-# Get current date for time logging form
-def currentDate():
-    return datetime.now()
+# # Get current date for time logging form
+# def currentDate():
+#     return datetime.now()
 
-# Time logging form blocks
-def timelog_form():
-    output = [
-        {
-            # Horizontal line
-            "type": "divider"
+num_entries_block = {
+    # Number of entries
+    "type": "input",
+    "block_id": "num_entries_block",
+    "element": { 
+        "type": "plain_text_input",
+        "action_id": "num_entries_input",
+        "initial_value": "20"
+    },
+    "label": {
+        "type": "plain_text",
+        "text": "Maximum number of entries to return for each user",
+    }
+}
+
+hours_input_block = {
+    # Hours input
+    "type": "input",
+    "block_id": "hours_block",
+    "element": {
+        "type": "plain_text_input",
+        "action_id": "hours_input"
+    },
+    "label": {
+        "type": "plain_text",
+        "text": "Time logged (e.g. 2h, 25m)",
+    }
+}
+
+user_select_block = {
+    "type": "input",
+    "block_id": "user_select_block",
+    "element": {
+        "type": "multi_users_select",
+        "placeholder": {
+            "type": "plain_text",
+            "text": "Select users",
         },
-        {
-            # Date picker
-            "type": "input",
-            "block_id": "date_select_block",
-            "element": {
-                "type": "datepicker",
-                # YYYY-MM-DD format needs to be used here because SQL doesn't have a date data type so these are stored as strings
-                # and in this format lexicographical order is identical to chronological order.
-                "initial_date": currentDate().strftime("%Y-%m-%d"),
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select a date",
-                },
-                "action_id": "date_select_input"
-            },
-            "label": {
-                "type": "plain_text",
-                "text": "Date to log",
-            }
-        },
-        {
-            # Hours input
-            "type": "input",
-            "block_id": "hours_block",
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "hours_input"
-            },
-            "label": {
-                "type": "plain_text",
-                "text": "Time logged (e.g. 2h, 25m)",
-            }
-        },
-        {
-            # Submit button
-            "type": "section",
+        "action_id": "user_select_input"
+    },
+    "label": {
+        "type": "plain_text",
+        "text": "Select users",
+    }
+}
+
+date_constraint_block = {
+    "block_id": "date_constraint_block",
+    "type": "input",
+    "element": {
+        "type": "static_select",
+        "initial_option": {
             "text": {
-                "type": "mrkdwn",
-                "text": "Click to submit and log hours"
-            },
-            "accessory": {
-                "type": "button",
-                "text": {
-                    "type": "plain_text",
-                    "text": "Submit",
-                },
-                "value": "placeholder",
-                "action_id": "timelog_response"
-            }
-        }
-    ]
-    return output
-
-# User selection form for hour sum
-def gethours_form():
-    output = [
-        {
-            "type": "input",
-            "block_id": "user_select_block",
-            "element": {
-                "type": "multi_users_select",
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select users",
-                },
-                "action_id": "user_select_input"
-            },
-            "label": {
                 "type": "plain_text",
-                "text": "Select users to view their total time logged",
-            }
-        },
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Confirm Selection",
-                    },
-                    "action_id": "gethours_response"
-                }
-            ]
-        }
-    ]
-    return output
-
-# User selection form for table
-def getusertables_form():
-    output = [
-        {
-            "type": "input",
-            "block_id": "user_select_block",
-            "element": {
-                "type": "multi_users_select",
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select users",
-                },
-                "action_id": "user_select_input"
+                "text": "This year",
             },
-            "label": {
-                "type": "plain_text",
-                "text": "Select users to their last n entries as a table",
-            }
+            "value": "This year"
         },
-        {
-            # Number of entries
-            "type": "input",
-            "block_id": "num_entries_block",
-            "element": { 
-                "type": "plain_text_input",
-                "action_id": "num_entries_input",
-                "initial_value": "20"
-            },
-            "label": {
-                "type": "plain_text",
-                "text": "Maximum number of entries to return for each user",
-            }
+        "placeholder": {
+            "type": "plain_text",
+            "text": "Select an item",
         },
-        # Add a date constraint selector
-        date_constraint(),
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Confirm Selection",
-                    },
-                    "action_id": "getusertables_response"
-                },
-            ]
-        }
-    ]
-    return output
-
-# This is a seperate function because it's a large block used in most of the commands and in some cases is the only 
-def date_constraint():
-    # Let the user choose a date constraint - the time_constraint_response event listener will run the function at
-    # response_endpoint with the given date constraint
-    today = datetime.today()
-    output = {
-        "block_id": "date_constraint_block",
-        "type": "input",
-        "element": {
-            "type": "static_select",
-            # Default to all time
-            "initial_option": {
+        "options": [
+            {
                 "text": {
                     "type": "plain_text",
                     "text": "This year",
                 },
                 "value": "This year"
             },
+            {
+                "text": {
+                    "type": "plain_text",
+                    "text": "Today",
+                },
+                "value": "today"
+            },
+            {
+                "text": {
+                    "type": "plain_text",
+                    "text": "This week",
+                },
+                "value": "this week"
+            },
+            {
+                "text": {
+                    "type": "plain_text",
+                    "text": "This month",
+                },
+                "value": "this month"
+            }
+        ],
+        "action_id": "time_constraint_input"
+    },
+    "label": {
+        "type": "plain_text",
+        "text": "Selection range",
+    }
+}
+
+def date_select_block():
+    return {
+        # Date picker
+        "type": "input",
+        "block_id": "date_select_block",
+        "element": {
+            "type": "datepicker",
+            # YYYY-MM-DD format needs to be used here because SQL doesn't have a date data type so these are stored as strings
+            # and in this format lexicographical order is identical to chronological order.
+            "initial_date": datetime.now().strftime("%Y-%m-%d"),
             "placeholder": {
                 "type": "plain_text",
-                "text": "Select an item",
+                "text": "Select a date",
             },
-            "options": [
-                {
-                    "text": {
-                        "type": "plain_text",
-                        "text": "This year",
-                    },
-                    "value": "This year"
-                },
-                {
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Today",
-                    },
-                    # "value": today
-                    "value": "today"
-                },
-                {
-                    "text": {
-                        "type": "plain_text",
-                        "text": "This week",
-                    },
-                    # Move back n days where n is the weekday number (so we reach the start of the week)
-                    # Monday is 0 and Sunday is 6 here
-                    # "value": today - timedelta(days = today.weekday())
-                    "value": "this week"
-                },
-                {
-                    "text": {
-                        "type": "plain_text",
-                        "text": "This month",
-                    },
-                    "value": "this month"
-                    # Replace the day part of the date with 1 (2022-11-23 becomes 2022-11-01)
-                    # "value": today.replace(day=1)
-                }
-            ],
-            "action_id": "time_constraint_input"
+            "action_id": "date_select_input"
         },
         "label": {
             "type": "plain_text",
-            "text": "Selection range",
+            "text": "Date to log",
         }
     }
 
-    print("got it")
-    return output
-
-# Time logging form blocks
-def dateoverview_form():
-    output = [
-        {
-            # Date picker
-            "type": "input",
-            "block_id": "date_select_block",
-            "element": {
-                "type": "datepicker",
-                "initial_date": currentDate().strftime("%Y-%m-%d"),
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select a date",
-                },
-                "action_id": "date_select_input"
-            },
-            "label": {
-                "type": "plain_text",
-                "text": "Date to log",
-            }
+def submit_button_block(form_action):
+    return {
+        # Submit button
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": "Confirm and submit"
         },
-        {
-            # Submit button
-            "type": "section",
+        "accessory": {
+            "type": "button",
             "text": {
-                "type": "mrkdwn",
-                "text": "Click to submit and log hours"
+                "type": "plain_text",
+                "text": "Submit",
             },
-            "accessory": {
-                "type": "button",
-                "text": {
-                    "type": "plain_text",
-                    "text": "Submit",
-                },
-                "value": "placeholder",
-                "action_id": "dateoverview_response"
-            }
+            "value": "placeholder",
+            "action_id": form_action
         }
+    }
+
+# Time logging form
+def timelog_form():
+    return [
+        date_select_block(),
+        hours_input_block,
+        submit_button_block("timelog_response")
     ]
-    return output
+
+# User selection form for hour sum
+def gethours_form():
+    return [
+        user_select_block,
+        submit_button_block("gethours_response")
+    ]
+
+def getusertables_form():
+    return [
+        user_select_block,
+        num_entries_block,
+        date_constraint_block(),
+        submit_button_block("getusertables_response")
+    ]
+
+def dateoverview_form():
+    return [
+        date_select_block,
+        submit_button_block("dateoverview_response")
+    ]
 
 def leaderboard_form():
-    output = [
-        {
-            # Date picker
-            "type": "input",
-            "block_id": "date_select_block",
-            "element": {
-                "type": "datepicker",
-                "initial_date": currentDate().strftime("%Y-%m-%d"),
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select a date",
-                },
-                "action_id": "date_select_input"
-            },
-            "label": {
-                "type": "plain_text",
-                "text": "Date to log",
-            }
-        },
-        {
-            # Submit button
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "Click to submit and log hours"
-            },
-            "accessory": {
-                "type": "button",
-                "text": {
-                    "type": "plain_text",
-                    "text": "Submit",
-                },
-                "value": "placeholder",
-                "action_id": "dateoverview_response"
-            }
-        }
+    return [
+        date_select_block(),
+        submit_button_block("leaderboard_response")
     ]
-
-
-
-# def time_constraint_form(response_endpoint):
-#     # Let the user choose a date constraint - the time_constraint_response event listener will run the function at
-#     # response_endpoint with the given date constraint
-#     today = date.today()
-#     output = [
-#         {
-#             "type": "input",
-#             "element": {
-#                 "type": "static_select",
-#                 "placeholder": {
-#                     "type": "plain_text",
-#                     "text": "Select an item",
-#                     "emoji": true
-#                 },
-#                 "options": [
-#                     {
-#                         "text": {
-#                             "type": "plain_text",
-#                             "text": "Today",
-#                             "emoji": true
-#                         },
-#                         "value": today
-#                     },
-#                     {
-#                         "text": {
-#                             "type": "plain_text",
-#                             "text": "This week",
-#                             "emoji": true
-#                         },
-#                         # Move back n days where n is the weekday number (so we reach the start of the week)
-#                         # Monday is 0 and Sunday is 6 here
-#                         "value": today - datetime.timedelta(days = today.weekday())
-#                     },
-#                     {
-#                         "text": {
-#                             "type": "plain_text",
-#                             "text": "This month",
-#                             "emoji": true
-#                         },
-#                         # Replace the day part of the date with 1 (2022-11-23 becomes 2022-11-01)
-#                         "value": today.replace(day=1)
-#                     },
-#                     {
-#                         "text": {
-#                             "type": "plain_text",
-#                             "text": "All time",
-#                             "emoji": true
-#                         },
-#                         "value": "All time"
-#                     }
-#                 ],
-#                 "value": response_endpoint,
-#                 "action_id": "time_constraint_response"
-#             },
-#             "label": {
-#                 "type": "plain_text",
-#                 "text": "Selection range",
-#                 "emoji": true
-#             }
-#         }
-#     ]

--- a/blocks.py
+++ b/blocks.py
@@ -1,6 +1,6 @@
 # Slack block kit - https://api.slack.com/block-kit
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # Get current date for time logging form
 def currentDate():
@@ -19,7 +19,8 @@ def timelog_form():
             "block_id": "date_select_block",
             "element": {
                 "type": "datepicker",
-                # YYYY-MM-DD format needs to be used here because SQL doesn't have a date data type so these are stored as strings - in this format lexicographical order is identical to chronological order.
+                # YYYY-MM-DD format needs to be used here because SQL doesn't have a date data type so these are stored as strings
+                # and in this format lexicographical order is identical to chronological order.
                 "initial_date": currentDate().strftime("%Y-%m-%d"),
                 "placeholder": {
                     "type": "plain_text",
@@ -132,6 +133,8 @@ def getusertables_form():
                 "text": "Number of entries to return for each user",
             }
         },
+        # Add a date constraint selector
+        date_constraint(),
         {
             "type": "actions",
             "elements": [
@@ -146,4 +149,128 @@ def getusertables_form():
             ]
         }
     ]
+    print(output)
     return output
+
+# If a seperate submit button is used a listener function will catch the default date_constraint_input event so it
+# won't do anything and won't show up in logs
+def date_constraint():
+    # Let the user choose a date constraint - the time_constraint_response event listener will run the function at
+    # response_endpoint with the given date constraint
+    today = datetime.today()
+    output = {
+        "type": "input",
+        "element": {
+            "type": "static_select",
+            "placeholder": {
+                "type": "plain_text",
+                "text": "Select an item",
+            },
+            "options": [
+                {
+                    "text": {
+                        "type": "plain_text",
+                        "text": "All time",
+                    },
+                    "value": "all_time"
+                },
+                {
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Today",
+                    },
+                    # "value": today
+                    "value": "today"
+                },
+                {
+                    "text": {
+                        "type": "plain_text",
+                        "text": "This week",
+                    },
+                    # Move back n days where n is the weekday number (so we reach the start of the week)
+                    # Monday is 0 and Sunday is 6 here
+                    # "value": today - timedelta(days = today.weekday())
+                    "value": "this_week"
+                },
+                {
+                    "text": {
+                        "type": "plain_text",
+                        "text": "This month",
+                    },
+                    "value": "this_month"
+                    # Replace the day part of the date with 1 (2022-11-23 becomes 2022-11-01)
+                    # "value": today.replace(day=1)
+                }
+            ],
+            "action_id": "time_constraint_input"
+        },
+        "label": {
+            "type": "plain_text",
+            "text": "Selection range",
+        }
+    }
+
+    print("got it")
+    return output
+
+# def time_constraint_form(response_endpoint):
+#     # Let the user choose a date constraint - the time_constraint_response event listener will run the function at
+#     # response_endpoint with the given date constraint
+#     today = date.today()
+#     output = [
+#         {
+#             "type": "input",
+#             "element": {
+#                 "type": "static_select",
+#                 "placeholder": {
+#                     "type": "plain_text",
+#                     "text": "Select an item",
+#                     "emoji": true
+#                 },
+#                 "options": [
+#                     {
+#                         "text": {
+#                             "type": "plain_text",
+#                             "text": "Today",
+#                             "emoji": true
+#                         },
+#                         "value": today
+#                     },
+#                     {
+#                         "text": {
+#                             "type": "plain_text",
+#                             "text": "This week",
+#                             "emoji": true
+#                         },
+#                         # Move back n days where n is the weekday number (so we reach the start of the week)
+#                         # Monday is 0 and Sunday is 6 here
+#                         "value": today - datetime.timedelta(days = today.weekday())
+#                     },
+#                     {
+#                         "text": {
+#                             "type": "plain_text",
+#                             "text": "This month",
+#                             "emoji": true
+#                         },
+#                         # Replace the day part of the date with 1 (2022-11-23 becomes 2022-11-01)
+#                         "value": today.replace(day=1)
+#                     },
+#                     {
+#                         "text": {
+#                             "type": "plain_text",
+#                             "text": "All time",
+#                             "emoji": true
+#                         },
+#                         "value": "All time"
+#                     }
+#                 ],
+#                 "value": response_endpoint,
+#                 "action_id": "time_constraint_response"
+#             },
+#             "label": {
+#                 "type": "plain_text",
+#                 "text": "Selection range",
+#                 "emoji": true
+#             }
+#         }
+#     ]

--- a/blocks.py
+++ b/blocks.py
@@ -221,6 +221,88 @@ def date_constraint():
     print("got it")
     return output
 
+# Time logging form blocks
+def dateoverview_form():
+    output = [
+        {
+            # Date picker
+            "type": "input",
+            "block_id": "date_select_block",
+            "element": {
+                "type": "datepicker",
+                "initial_date": currentDate().strftime("%Y-%m-%d"),
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select a date",
+                },
+                "action_id": "date_select_input"
+            },
+            "label": {
+                "type": "plain_text",
+                "text": "Date to log",
+            }
+        },
+        {
+            # Submit button
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Click to submit and log hours"
+            },
+            "accessory": {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Submit",
+                },
+                "value": "placeholder",
+                "action_id": "dateoverview_response"
+            }
+        }
+    ]
+    return output
+
+def leaderboard_form():
+    output = [
+        {
+            # Date picker
+            "type": "input",
+            "block_id": "date_select_block",
+            "element": {
+                "type": "datepicker",
+                "initial_date": currentDate().strftime("%Y-%m-%d"),
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select a date",
+                },
+                "action_id": "date_select_input"
+            },
+            "label": {
+                "type": "plain_text",
+                "text": "Date to log",
+            }
+        },
+        {
+            # Submit button
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Click to submit and log hours"
+            },
+            "accessory": {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Submit",
+                },
+                "value": "placeholder",
+                "action_id": "dateoverview_response"
+            }
+        }
+    ]
+
+
+
 # def time_constraint_form(response_endpoint):
 #     # Let the user choose a date constraint - the time_constraint_response event listener will run the function at
 #     # response_endpoint with the given date constraint

--- a/blocks.py
+++ b/blocks.py
@@ -1,6 +1,8 @@
 # Slack block kit - https://api.slack.com/block-kit
 # Each slack block used is stored here as a single dictionary object. These are then combined into a list of blocks for each message.
 
+#  Clicking the submit button for a form will send a block_action payload with the user-input content from the form stored in a dictionary.
+# All inputs are stored as strings, integers, and booleans. Dates are stored as strings in the YYYY-MM-DD format.
 from datetime import date, timedelta
 
 num_entries_block = {

--- a/blocks.py
+++ b/blocks.py
@@ -182,7 +182,6 @@ def getusertables_form():
     return [
         user_select_block,
         num_entries_block,
-        date_constraint_block,
         submit_button_block("getusertables_response")
     ]
 

--- a/blocks.py
+++ b/blocks.py
@@ -1,10 +1,7 @@
 # Slack block kit - https://api.slack.com/block-kit
+# Each slack block used is stored here as a single dictionary object. These are then combined into a list of blocks for each message.
 
-from datetime import datetime, timedelta
-
-# # Get current date for time logging form
-# def currentDate():
-#     return datetime.now()
+from datetime import date, timedelta
 
 num_entries_block = {
     # Number of entries
@@ -19,6 +16,10 @@ num_entries_block = {
         "type": "plain_text",
         "text": "Maximum number of entries to return for each user",
     }
+}
+
+divider = {
+    "type": "divider"
 }
 
 num_users_block = {
@@ -122,16 +123,30 @@ date_constraint_block = {
     }
 }
 
-def date_select_block():
+def text_field_block(label, max_length):
     return {
-        # Date picker
         "type": "input",
-        "block_id": "date_select_block",
+        "block_id": "text_field_block",
+        "element": {
+            "type": "plain_text_input",
+            "action_id": "text_input",
+            "max_length": max_length
+        },
+        "label": {
+            "type": "plain_text",
+            "text": label
+        }
+    }
+
+# Getter functions are used when the block has dynamic content
+def date_select_block(label, initial_date, id_modifier = None):
+    block_id = "date_select_block_" + id_modifier if id_modifier else "date_select_block"
+    return {
+        "type": "input",
+        "block_id": block_id,
         "element": {
             "type": "datepicker",
-            # YYYY-MM-DD format needs to be used here because SQL doesn't have a date data type so these are stored as strings
-            # and in this format lexicographical order is identical to chronological order.
-            "initial_date": datetime.now().strftime("%Y-%m-%d"),
+            "initial_date": initial_date.strftime("%Y-%m-%d"),
             "placeholder": {
                 "type": "plain_text",
                 "text": "Select a date",
@@ -140,42 +155,42 @@ def date_select_block():
         },
         "label": {
             "type": "plain_text",
-            "text": "Date to log",
+            "text": label,
         }
     }
 
 def submit_button_block(form_action):
     return {
-        # Submit button
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": "Confirm and submit"
-        },
-        "accessory": {
-            "type": "button",
-            "text": {
-                "type": "plain_text",
-                "text": "Submit",
-            },
-            "value": "placeholder",
-            "action_id": form_action
-        }
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Confirm",
+                },
+                "value": "confirm",
+                "action_id": form_action
+            }
+        ]
     }
 
 # Time logging form
 def timelog_form():
     return [
-        date_select_block(),
+        date_select_block("Date to log", date.today()),
         hours_input_block,
+        # 72 characters is the max length of a git commit message
+        text_field_block("Summary of work done", 70),
         submit_button_block("timelog_response")
     ]
 
 # User selection form for hour sum
-def gethours_form():
+def getentries_form():
     return [
         user_select_block,
-        submit_button_block("gethours_response")
+        num_entries_block,
+        submit_button_block("getentries_response")
     ]
 
 def getusertables_form():
@@ -187,12 +202,13 @@ def getusertables_form():
 
 def dateoverview_form():
     return [
-        date_select_block,
+        date_select_block("Date to view", date.today()),
         submit_button_block("dateoverview_response")
     ]
 
 def leaderboard_form():
     return [
-        date_constraint_block,
+        date_select_block("Start date", date.today() - timedelta(days=365), "start"),
+        date_select_block("End date", date.today(), "end"),
         submit_button_block("leaderboard_response")
     ]

--- a/blocks.py
+++ b/blocks.py
@@ -152,8 +152,7 @@ def getusertables_form():
     ]
     return output
 
-# If a seperate submit button is used a listener function will catch the default date_constraint_input event so it
-# won't do anything and won't show up in logs
+# This is a seperate function because it's a large block used in most of the commands and in some cases is the only 
 def date_constraint():
     # Let the user choose a date constraint - the time_constraint_response event listener will run the function at
     # response_endpoint with the given date constraint
@@ -167,9 +166,9 @@ def date_constraint():
             "initial_option": {
                 "text": {
                     "type": "plain_text",
-                    "text": "All time",
+                    "text": "This year",
                 },
-                "value": "all time"
+                "value": "This year"
             },
             "placeholder": {
                 "type": "plain_text",
@@ -179,9 +178,9 @@ def date_constraint():
                 {
                     "text": {
                         "type": "plain_text",
-                        "text": "All time",
+                        "text": "This year",
                     },
-                    "value": "all time"
+                    "value": "This year"
                 },
                 {
                     "text": {

--- a/blocks.py
+++ b/blocks.py
@@ -78,7 +78,7 @@ date_constraint_block = {
                 "type": "plain_text",
                 "text": "This year",
             },
-            "value": "This year"
+            "value": "this year"
         },
         "placeholder": {
             "type": "plain_text",
@@ -90,7 +90,7 @@ date_constraint_block = {
                     "type": "plain_text",
                     "text": "This year",
                 },
-                "value": "This year"
+                "value": "this year"
             },
             {
                 "text": {

--- a/blocks.py
+++ b/blocks.py
@@ -186,6 +186,14 @@ def timelog_form():
     ]
 
 # User selection form for hour sum
+def gethours_form():
+    return [
+        user_select_block,
+        date_select_block("Start date", date.today() - timedelta(days=365), "start"),
+        date_select_block("End date", date.today(), "end"),
+        submit_button_block("gethours_response")
+    ]
+
 def getentries_form():
     return [
         user_select_block,

--- a/database.py
+++ b/database.py
@@ -92,6 +92,7 @@ class SQLConnection:
                                   FROM time_log tl
                                   INNER JOIN user_names u
                                   ON tl.user_id=u.user_id
+                                  ORDER BY tl.selected_date DESC, tl.entry_num DESC
                                   LIMIT ? """, (num_entries,))
         return(res.fetchall())
 

--- a/database.py
+++ b/database.py
@@ -120,20 +120,9 @@ class SQLConnection:
             return(minutes)
         else:
             return(0)
-
-    # Get total minutes logged by all users
-    def all_time_sums(self):
-        # If the user has entries in the database return their total time logged
-        res = self.cur.execute("""SELECT u.name, u.display_name, SUM(tl.minutes) AS time_sum
-                                  FROM time_log tl
-                                  INNER JOIN user_names u
-                                  ON u.user_id=tl.user_id
-                                  GROUP BY u.name, u.display_name
-                                  ORDER BY time_sum;""")
-        return(res.fetchall())
-
+            
     # Get the top 10 contributors
-    def leaderboard(self, num_users = None, date_constraint = None):
+    def leaderboard(self, date_constraint = None):
         query = """SELECT u.name, u.display_name, sum(tl.minutes) AS totalMinutes
                  FROM user_names u
                  INNER JOIN time_log tl
@@ -143,14 +132,8 @@ class SQLConnection:
             query += "WHERE selected_date >= ? AND selected_date <= ? "
             params.append(date_constraint.start_date)
             params.append(date_constraint.end_date)
-        # query += """ """ # Close the WHERE clause
         query += """GROUP BY u.name, u.display_name
                     ORDER BY totalMinutes DESC """
-        if num_users:
-            query += "LIMIT ?"
-            params.append(num_users)
-        print(query)
-        print(params)
         res = self.cur.execute(query, params)
         return(res.fetchall())
 

--- a/database.py
+++ b/database.py
@@ -122,19 +122,15 @@ class SQLConnection:
             return(0)
 
     # Get the top 10 contributors
-    def leaderboard(self, date_constraint = None):
-        query = """SELECT u.name, u.display_name, sum(tl.minutes) AS totalMinutes
-                 FROM user_names u
-                 INNER JOIN time_log tl
-                 ON u.user_id=tl.user_id """
-        params = []
-        if date_constraint:
-            query += "WHERE selected_date >= ? AND selected_date <= ? "
-            params.append(date_constraint.start_date.strftime('%Y-%m-%d'))
-            params.append(date_constraint.end_date.strftime('%Y-%m-%d'))
-        query += """GROUP BY u.name, u.display_name
-                    ORDER BY totalMinutes DESC """
-        res = self.cur.execute(query, params)
+    def leaderboard(self, start_date = None, end_date = None):
+        res = self.cur.execute("""SELECT u.name, u.display_name, sum(tl.minutes) AS totalMinutes
+                                  FROM user_names u
+                                  INNER JOIN time_log tl
+                                  ON u.user_id=tl.user_id
+                                  WHERE selected_date >= ? 
+                                  AND selected_date <= ?
+                                  GROUP BY u.name, u.display_name
+                                  ORDER BY totalMinutes DESC """, start_date, end_date)
         return(res.fetchall())
 
     def entries_for_date_list(self, selected_date):

--- a/database.py
+++ b/database.py
@@ -141,3 +141,13 @@ class SQLConnection:
                                   ORDER BY totalMinutes DESC
                                   LIMIT ?;""", (num_users,))
         return(res.fetchall())
+
+    def entries_for_date_table(self, selected_date):
+        # Get all entries by all users
+        res = self.cur.execute("""SELECT u.name, tl.minutes
+                                FROM time_log tl
+                                INNER JOIN user_names u
+                                ON tl.user_id=u.user_id
+                                WHERE tl.selected_date=?;""", (selected_date,))
+        header = ["Name", "Minutes"]
+        return(tabulate(res.fetchall(), header, tablefmt="simple_grid"))

--- a/database.py
+++ b/database.py
@@ -120,7 +120,7 @@ class SQLConnection:
             return(minutes)
         else:
             return(0)
-            
+
     # Get the top 10 contributors
     def leaderboard(self, date_constraint = None):
         query = """SELECT u.name, u.display_name, sum(tl.minutes) AS totalMinutes
@@ -130,8 +130,8 @@ class SQLConnection:
         params = []
         if date_constraint:
             query += "WHERE selected_date >= ? AND selected_date <= ? "
-            params.append(date_constraint.start_date)
-            params.append(date_constraint.end_date)
+            params.append(date_constraint.start_date.strftime('%Y-%m-%d'))
+            params.append(date_constraint.end_date.strftime('%Y-%m-%d'))
         query += """GROUP BY u.name, u.display_name
                     ORDER BY totalMinutes DESC """
         res = self.cur.execute(query, params)
@@ -145,5 +145,4 @@ class SQLConnection:
                                 ON tl.user_id=u.user_id
                                 WHERE tl.selected_date=?;""", (selected_date,))
         header = ["Name", "Minutes"]
-        print(selected_date)
         return(tabulate(res.fetchall(), header, tablefmt="simple_grid"))

--- a/database.py
+++ b/database.py
@@ -140,9 +140,9 @@ class SQLConnection:
                  ON u.user_id=tl.user_id """
         params = []
         if date_constraint:
-            query += "WHERE selected_date > ? AND selected_date < ? "
-            params.append(date_constraint.start_date.date())
-            params.append(date_constraint.end_date.date())
+            query += "WHERE selected_date >= ? AND selected_date <= ? "
+            params.append(date_constraint.start_date)
+            params.append(date_constraint.end_date)
         # query += """ """ # Close the WHERE clause
         query += """GROUP BY u.name, u.display_name
                     ORDER BY totalMinutes DESC """

--- a/database.py
+++ b/database.py
@@ -83,8 +83,8 @@ class SQLConnection:
         self.cur.execute("""DELETE FROM time_log
                             WHERE (user_id, entry_num) IN (
                                 SELECT user_id, entry_num FROM time_log
-                                WHERE user_id = ? ORDER BY
-                                entry_num DESC LIMIT 1);""", (user_id,))
+                                WHERE user_id = ? 
+                                ORDER BY entry_num DESC LIMIT 1);""", (user_id,))
 
     # Get all entries by all users
     def timelog_table(self):
@@ -97,11 +97,13 @@ class SQLConnection:
         return(tabulate(res.fetchall(), header, tablefmt="simple_grid"))
 
     # Get the last n entries by user as a table
-    def last_entries_table(self, user_id, num_entries):
+    def last_entries_table(self, user_id, num_entries, start_date = ""):
         res = self.cur.execute("""SELECT entry_num, entry_date, selected_date, minutes
-                                FROM time_log WHERE user_id = ?
+                                FROM time_log 
+                                WHERE user_id = ?
+                                AND selected_date > ?
                                 ORDER BY entry_num DESC
-                                LIMIT ?;""", (user_id, num_entries))
+                                LIMIT ?;""", (user_id, start_date, num_entries))
         header = ["Entry Number", "Date Submitted", "Date of Log", "Minutes"]
         return(tabulate(res.fetchall(), header, tablefmt="simple_grid"))
 
@@ -127,17 +129,6 @@ class SQLConnection:
                                   GROUP BY u.name, u.display_name
                                   ORDER BY time_sum;""")
         return(res.fetchall())
-
-    # Get total minutes logged by user with given user_id within the given number of days of the current date
-    def time_sum_after_date(self, user_id, days):
-        today = datetime.date.today().strftime('%Y-%m-%d')
-        startDate = today - datetime.timedelta(days)
-        # If the user has entries in the database return their time logged within the specified period, otherwise return 0
-        minutes = res.fetchone()[0]
-        if (minutes != None):
-            return(minutes)
-        else:
-            return(0)
 
     # Get the top 10 contributors
     def leaderboard(self, num_users):

--- a/database.py
+++ b/database.py
@@ -35,8 +35,7 @@ def create_user_table():
 # SQLite3 documentation says placeholder question marks and a tuple of values should be used rather than formatted strings to prevent sql injection attacks
 # Ot's probably not important in this project but there's no reason not to do it this way
 
-# All public methods in this class assume date is being given as a date object, not a string. This means multiple conversions are needed sometimes but it
-# keeps things consistent and makes the whole program easier to maintain.
+# All public methods in this class assume date is being given as a string in the YYYY-MM-DD format. This is because the Slack block forms return dates as strings and SQLite stores dates as strings.
 
 class SQLConnection:
     def __init__(self):
@@ -106,9 +105,6 @@ class SQLConnection:
 
     # Get total minutes logged by user with given user_id
     def time_sum(self, user_id, start_date = None, end_date = None):
-        # If the user has entries in the database return their total time logged, otherwise return 0
-        start_date = start_date.strftime('%Y-%m-%d')
-        end_date = end_date.strftime('%Y-%m-%d')
         res = self.cur.execute("""SELECT SUM(minutes)
                                   FROM time_log
                                   WHERE user_id = ?
@@ -132,8 +128,8 @@ class SQLConnection:
     def entries_for_date_list(self, selected_date):
         # Get all entries by all users
         res = self.cur.execute("""SELECT u.name, u.display_name, tl.minutes, tl.summary
-                                FROM time_log tl
-                                INNER JOIN user_names u
-                                ON tl.user_id=u.user_id
-                                WHERE tl.selected_date=? """, (selected_date,))
+                                  FROM time_log tl
+                                  INNER JOIN user_names u
+                                  ON tl.user_id=u.user_id
+                                  WHERE tl.selected_date=? """, (selected_date,))
         return(res.fetchall())

--- a/database.py
+++ b/database.py
@@ -83,17 +83,17 @@ class SQLConnection:
                                 WHERE user_id = ? 
                                 ORDER BY entry_num DESC LIMIT 1) """, (user_id,))
 
-    # Get all entries by all users
-    def all_entries_list(self):
-        res = self.cur.execute("""SELECT u.name, tl.entry_num, tl.entry_date, tl.selected_date, tl.minutes
+    # Get last entries by all users
+    def all_user_entries_list(self, num_entries):
+        res = self.cur.execute("""SELECT u.name, u.display_name, tl.selected_date, tl.minutes, tl.entry_date, tl.summary
                                   FROM time_log tl
                                   INNER JOIN user_names u
                                   ON tl.user_id=u.user_id
-                                  LIMIT 30 """)
+                                  LIMIT ? """, (num_entries,))
         return(res.fetchall())
 
     # Get the last n entries by user
-    def last_entries_list(self, user_id, num_entries = 10):
+    def given_user_entries_list(self, user_id, num_entries = 10):
         res = self.cur.execute("""SELECT selected_date, minutes, entry_date, summary
                                 FROM time_log 
                                 WHERE user_id = ?
@@ -110,8 +110,8 @@ class SQLConnection:
         params = [user_id]
         if (start_date and end_date):
             query += "AND selected_date >= ? AND selected_date <= ? "
-            params.append(start_date.strftime('%Y-%m-%d'))
-            params.append(end_date.strftime('%Y-%m-%d'))
+            params.append(start_date)
+            params.append(end_date)
         elif (start_date or end_date):
             raise ValueError("Both start and end dates must be specified if one is specified")
         res = self.cur.execute(query, params)

--- a/database.py
+++ b/database.py
@@ -42,6 +42,7 @@ class SQLConnection:
         # Open SQL connection
         self.con = sqlite3.connect(db_file)
         self.cur = self.con.cursor()
+        self.cur.row_factory = sqlite3.Row
 
     def __del__(self):
         # Close SQL connection (saving changes to file)

--- a/database.py
+++ b/database.py
@@ -130,7 +130,7 @@ class SQLConnection:
                                   WHERE selected_date >= ? 
                                   AND selected_date <= ?
                                   GROUP BY u.name, u.display_name
-                                  ORDER BY totalMinutes DESC """, start_date, end_date)
+                                  ORDER BY totalMinutes DESC """, (start_date, end_date))
         return(res.fetchall())
 
     def entries_for_date_list(self, selected_date):


### PR DESCRIPTION
**Summary**
- Replace tables with list-based responses
- Add summary of work to logs
- Improve structure of slack blocks module
- Add date constraints to admin commands
- Add yearly and weekly summary for /getentries
- Improve error handling

I think the tables were much more readable. It wouldn't be too difficult to add them back as a user preference (just a bool attribute in the user table) but maybe that's just extra complexity we don't need.

![image](https://user-images.githubusercontent.com/54734963/201783188-375a3920-0d00-4248-961b-94601221c6af.png)

<img src="https://user-images.githubusercontent.com/54734963/201783207-ae23a752-fd92-441a-90e9-2bedd2070eb1.png" width="300" alt="phone-list">

<img src="https://user-images.githubusercontent.com/54734963/201784029-ae13c404-ee4b-4009-a4f3-6f005d0a2027.png" width="500" alt="phone-list">

<img src="https://user-images.githubusercontent.com/54734963/201784276-a6bdbd86-30f5-44d5-b639-a49f5d31c647.png" width="500" alt="phone-list">
